### PR TITLE
Fix banned until time in UI

### DIFF
--- a/public/js/components/pages/Xban.js
+++ b/public/js/components/pages/Xban.js
@@ -106,7 +106,7 @@ export default {
                         </ul>
                     </td>
                     <td>{{format_time(record.last_seen)}}</td>
-                    <td>{{format_time(record.time)}}</td>
+                    <td>{{record.expires ? format_time(record.expires) : "permanent"}}</td>
                 </tr>
             </tbody>
         </table>


### PR DESCRIPTION
Banned until shows ban issuance timestamp, there's no need to move it anywhere because it is already there in previous column.
Makes banned-until-column display correct ban expiration time if there's one or "permanent" if there's no expiration time set.