### PR TITLE
support for place and biome names

### DIFF
--- a/public/js/components/pages/OnlinePlayers.js
+++ b/public/js/components/pages/OnlinePlayers.js
@@ -34,6 +34,7 @@ export default {
                     <th>Name</th>
                     <th>Health</th>
                     <th v-if="has_priv('ban')">Position</th>
+                    <th v-if="has_priv('ban')">Location</th>
                     <th v-if="has_priv('ban')">Address</th>
                     <th v-if="has_priv('ban')">Protocol-Version</th>
                     <th v-if="has_priv('ban')">Connected since</th>
@@ -55,6 +56,9 @@ export default {
                     </td>
                     <td v-if="has_priv('ban')">
                         {{Math.floor(player.pos.x)}}/{{Math.floor(player.pos.y)}}/{{Math.floor(player.pos.z)}}
+                    </td>
+                    <td v-if="has_priv('ban')">
+                        {{player.loc}}
                     </td>
                     <td v-if="has_priv('ban')">
                         {{player.info.address}}

--- a/types/command/stats.go
+++ b/types/command/stats.go
@@ -20,6 +20,7 @@ type PlayerStats struct {
 		Y types.JsonInt `json:"y"`
 		Z types.JsonInt `json:"z"`
 	} `json:"pos"`
+	Loc   string       `json:"loc"`
 
 	Info *struct {
 		Address              string        `json:"address"`

--- a/web/stats.go
+++ b/web/stats.go
@@ -64,6 +64,7 @@ func (a *Api) GetStats(w http.ResponseWriter, r *http.Request, claims *types.Cla
 			if claims != nil && claims.HasPriv("ban") {
 				// infos for provileged users
 				p.Pos = ps.Pos
+				p.Loc = ps.Loc
 				p.Info = ps.Info
 			}
 


### PR DESCRIPTION
This ties in with [mtui_mod#16](https://github.com/minetest-go/mtui_mod/pull/16). It works gracefully without mod respawn used, by just showing the biome name. The same privilege is required to view named location as to view pos x/y/z.