### PR TITLE
Add configurable engine logging

### DIFF
--- a/app/services.go
+++ b/app/services.go
@@ -28,7 +28,7 @@ func (app *App) SetupServices() {
 			Networks:         strings.Split(app.Config.DockerNetwork, ","),
 			InternalNetworks: strings.Split(app.Config.DockerNetworkInternal, ","),
 			DefaultConfig: &container.Config{
-				Cmd:  []string{"--world", "/world", "--config", "/minetest.conf"},
+				Cmd:  app.Config.MinetestCommand(),
 				Tty:  false,
 				User: fmt.Sprintf("%d", os.Getuid()),
 				Env:  no_proxy_env,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,8 @@ services:
    GEOIP_API: "https://hosting.minetest.ch/api/geoip"
    DOCKER_MINETEST_CONFIG: "${PWD}/minetest.conf"
    DOCKER_MINETEST_PORT: 30000
+   DOCKER_MINETEST_LOG_LEVEL: "info"
+   DOCKER_MINETEST_LOGFILE: "/world/debug.txt"
    DOCKER_HOSTNAME: "ui"
    DOCKER_NETWORK: "mtui_default"
    DOCKER_INTERNAL_NETWORK: "mtui_internal"

--- a/docs/install.md
+++ b/docs/install.md
@@ -14,6 +14,8 @@ Environment variables:
 * `SERVER_NAME` Server-name to display on the ui
 * `ENABLE_FEATURES` manually enabled features
 * `MINETEST_CONFIG` set this to the `minetest.conf` location to enable the settings-management
+* `DOCKER_MINETEST_LOG_LEVEL` Luanti console level, defaults to "action". Possible values: "action", "info", "verbose", "trace" and "quiet"
+* `DOCKER_MINETEST_LOGFILE` engine container logfile path, defaults to "/world/debug.txt"
 
 # Using docker-compose
 You must use file `docker-compose.yml` from this entire repository directory, because it pulls in the app files from this repository. You cannot run it in a bare directory.

--- a/types/config.go
+++ b/types/config.go
@@ -6,6 +6,18 @@ import (
 	"strings"
 )
 
+func (c *Config) MinetestCommand() []string {
+	cmd := []string{"--world", "/world", "--config", "/minetest.conf"}
+	if c.DockerMinetestLogLevel != "" && c.DockerMinetestLogLevel != "action" {
+		cmd = append(cmd, "--"+c.DockerMinetestLogLevel)
+	}
+	logfile := c.DockerMinetestLogfile
+	if logfile == "" {
+		logfile = "/world/debug.txt"
+	}
+	return append(cmd, "--logfile", logfile)
+}
+
 // env provided configuration flags
 type Config struct {
 	WorldDir                string
@@ -26,6 +38,8 @@ type Config struct {
 	GeoIPAPI                string
 	DockerMinetestConfig    string
 	DockerMinetestPort      int
+	DockerMinetestLogLevel  string
+	DockerMinetestLogfile   string
 	WASMMinetestHost        string
 	DockerHostname          string
 	DockerNetwork           string
@@ -57,6 +71,8 @@ func NewConfig(world_dir string) *Config {
 		GeoIPAPI:                os.Getenv("GEOIP_API"),
 		DockerMinetestConfig:    os.Getenv("DOCKER_MINETEST_CONFIG"),
 		DockerMinetestPort:      int(port),
+		DockerMinetestLogLevel:  os.Getenv("DOCKER_MINETEST_LOG_LEVEL"),
+		DockerMinetestLogfile:   os.Getenv("DOCKER_MINETEST_LOGFILE"),
 		WASMMinetestHost:        os.Getenv("WASM_MINETEST_HOST"),
 		DockerHostname:          os.Getenv("DOCKER_HOSTNAME"),
 		DockerNetwork:           os.Getenv("DOCKER_NETWORK"),

--- a/types/config_test.go
+++ b/types/config_test.go
@@ -1,0 +1,31 @@
+package types
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestMinetestCommand(t *testing.T) {
+	want := []string{
+		"--world", "/world",
+		"--config", "/minetest.conf",
+		"--info",
+		"--logfile", "/logs/luanti.log",
+	}
+	cfg := Config{DockerMinetestLogLevel: "info", DockerMinetestLogfile: "/logs/luanti.log"}
+	if got := cfg.MinetestCommand(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected command: %v", got)
+	}
+}
+
+func TestMinetestCommandDefaultsLogfileToWorld(t *testing.T) {
+	want := []string{
+		"--world", "/world",
+		"--config", "/minetest.conf",
+		"--logfile", "/world/debug.txt",
+	}
+	cfg := Config{DockerMinetestLogLevel: "action"}
+	if got := cfg.MinetestCommand(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected command: %v", got)
+	}
+}


### PR DESCRIPTION
My first time programming in Go, so I hope I haven't done anything weird haha.

On the AES server we were unable to debug a crash because we needed to have info-level debug: Luanti’s `debug_log_level` setting controls file logging, while the engine’s Docker console verbosity is configured through flags such as `--info`. I've added `DOCKER_MINETEST_LOG_LEVEL` and `DOCKER_MINETEST_LOGFILE` (default `/world/debug.txt`) so an external application or script can access it without having to re-print logs everytime.

Also added a simple test for it since I've seen you have them for other things too